### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/api/metadata_api.py
+++ b/api/metadata_api.py
@@ -94,9 +94,9 @@ def rebuild_cache(f):
                     cache.write(u', ')
 
                 if field in ['title', 'translated_title', 'subtitle', 'tags', 'learn_more_or_download_data']:
-                    cache.write(u'"%s": "%s"' % (field, markdown2.markdown(md[layer][field]).replace('"', '\\"').replace(u'\n', u'').replace(u'<p>', u'').replace(u'</p>', u'').strip()))
+                    cache.write(u'"{0!s}": "{1!s}"'.format(field, markdown2.markdown(md[layer][field]).replace('"', '\\"').replace(u'\n', u'').replace(u'<p>', u'').replace(u'</p>', u'').strip()))
                 else:
-                    cache.write(u'"%s": "%s"' % (field, markdown2.markdown(md[layer][field]).replace('"', '\\"').replace(u'\n', u'').replace(u'<p></p>', u'').strip()))
+                    cache.write(u'"{0!s}": "{1!s}"'.format(field, markdown2.markdown(md[layer][field]).replace('"', '\\"').replace(u'\n', u'').replace(u'<p></p>', u'').strip()))
 
                 j += 1
             cache.write(u'}')

--- a/push_imazon.py
+++ b/push_imazon.py
@@ -18,7 +18,7 @@ def cartodb_sql(sql, raise_error=True):
     result = urllib.urlopen("http://wri-01.cartodb.com:80/api/v2/sql?api_key={0!s}&q={1!s}".format(key, sql))
     json_result = json.loads(result.readlines()[0])
     if raise_error and  "error" in json_result.keys():
-        raise SyntaxError("Wrong SQL syntax.\n %s" %json_result['error'])
+        raise SyntaxError("Wrong SQL syntax.\n {0!s}".format(json_result['error']))
     return json_result
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wri:gfw-sync?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wri:gfw-sync?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)